### PR TITLE
Use next/image to display user avatars

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  images: {
+    // The next/image component requires us to specify the exact
+    // domain when serving images from an external domain.
+    // There is a feature request to allow wildcard hostnames
+    // https://github.com/vercel/next.js/issues/18632
+    //
+    // Meanwhile, we have to maintain a list of possible github urls
+    domains: [
+      'avatars1.githubusercontent.com',
+      'avatars2.githubusercontent.com',
+      'avatars3.githubusercontent.com',
+      'avatars4.githubusercontent.com',
+      'avatars5.githubusercontent.com',
+      'avatars6.githubusercontent.com',
+      'avatars7.githubusercontent.com',
+      'avatars8.githubusercontent.com',
+    ],
+  },
+};

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,4 +1,5 @@
 import cn from 'classnames';
+import Image from 'next/image';
 import { format } from 'timeago.js';
 import MergedIcon from '@/components/icons/merge';
 import PullRequestIcon from '@/components/icons/pullrequest';
@@ -82,7 +83,9 @@ export default function Card(data) {
           href={author.url}
           title={author.login}
         >
-          <img
+          <Image
+            width="40"
+            height="40"
             className="w-10 p-0.5 border-2 border-purple-600 rounded-full"
             alt={author.login}
             src={author.avatarUrl}


### PR DESCRIPTION
Use `next/image` component to serve user avatars. This requires us to specify the exact domain when serving images from an external domain. There is a feature request to allow wildcard hostnames https://github.com/vercel/next.js/issues/18632
    
Meanwhile, we have to maintain a list of possible github urls